### PR TITLE
 #317: Correct --shuffle Flag Behavior and Documentation

### DIFF
--- a/lib/judges/judges.rb
+++ b/lib/judges/judges.rb
@@ -62,10 +62,10 @@ class Judges::Judges
   # This method discovers all judge directories, validates them (ensuring they contain
   # a corresponding .rb file), and yields them in a specific order. The order is
   # determined by:
-  # 1. Judges whose names match the boost list are placed first
-  # 2. Judges whose names start with the shuffle prefix are randomly reordered
+  # 1. Randomly reorder judges (if shuffle prefix is empty, shuffle all judges;
+  #    if prefix is not empty, shuffle only those NOT starting with the prefix)
+  # 2. Judges whose names match the boost list are placed first
   # 3. Judges whose names match the demote list are placed last
-  # 4. All other judges maintain their alphabetical order
   #
   # @yield [Judges::Judge] Yields each valid judge object
   # @return [Enumerator] Returns an enumerator if no block is given
@@ -84,7 +84,7 @@ class Judges::Judges
     good = all.dup
     mapping = all
       .map { |a| [a[0].name, a[1], a[1]] }
-      .reject { |a| a[0].start_with?(@shuffle) }
+      .reject { |a| !@shuffle.empty? && a[0].start_with?(@shuffle) }
       .to_h { |a| [a[1], a[2]] }
     positions = mapping.values.shuffle
     mapping.keys.zip(positions).to_h.each do |before, after|

--- a/test/test_judges.rb
+++ b/test/test_judges.rb
@@ -41,7 +41,7 @@ class TestJudges < Minitest::Test
       assert_equal('blueberry', list[2].name)
       refute_equal(names.join(' '), list.map(&:name).join(' '))
       list = Judges::Judges.new(d, nil, Loog::NULL, shuffle: '').each.to_a
-      assert_equal(names.join(' '), list.map(&:name).join(' '))
+      refute_equal(names.join(' '), list.map(&:name).join(' '))
     end
   end
 
@@ -54,6 +54,7 @@ class TestJudges < Minitest::Test
       end
       list = Judges::Judges.new(d, nil, Loog::NULL, shuffle: '', boost: ['yellow']).each.to_a
       assert_equal('yellow', list[0].name)
+      refute_equal((names - ['yellow']).join(' '), list[1..].map(&:name).join(' '))
     end
   end
 
@@ -114,7 +115,9 @@ class TestJudges < Minitest::Test
       end
       list = Judges::Judges.new(d, nil, Loog::NULL, demote: %w[beta delta]).each.to_a
       result = list.map(&:name)
-      assert_equal(%w[alpha epsilon gamma beta delta], result)
+      demoted = result[-2..]
+      assert_includes(demoted, 'beta')
+      assert_includes(demoted, 'delta')
     end
   end
 
@@ -125,10 +128,11 @@ class TestJudges < Minitest::Test
         dir = File.join(d, n)
         save_it(File.join(dir, "#{n}.rb"), 'puts 1')
       end
-      list = Judges::Judges.new(d, nil, Loog::NULL, boost: %w[six two], demote: %w[one four]).each.to_a
+      list = Judges::Judges.new(d, nil, Loog::NULL, boost: %w[six two], demote: %w[one four], shuffle: 'xyz').each.to_a
       result = list.map(&:name)
-      assert_equal('six', result[0])
-      assert_equal('two', result[1])
+      boosted = result[0..1]
+      assert_includes(boosted, 'six')
+      assert_includes(boosted, 'two')
       demoted = result[-2..]
       assert_includes(demoted, 'one')
       assert_includes(demoted, 'four')


### PR DESCRIPTION
Closes #317 

This pull request updates the judge ordering logic and its corresponding tests to improve the handling of shuffling, boosting, and demoting judges. The main change is to shuffle all judges when the shuffle prefix is empty, rather than maintaining alphabetical order, and to adjust the order of operations for shuffling, boosting, and demoting. The tests have been updated to reflect these new behaviors.

**Judge ordering logic updates:**

* The shuffle step now shuffles all judges when the shuffle prefix is empty; if a prefix is provided, only judges not starting with that prefix are shuffled. The boost and demote steps are applied after shuffling. (`lib/judges/judges.rb`) [[1]](diffhunk://#diff-6657a041541284f287d3549f7a3f13f8e7502cef90d9dec63f51daf895c5e110L65-L68) [[2]](diffhunk://#diff-6657a041541284f287d3549f7a3f13f8e7502cef90d9dec63f51daf895c5e110L87-R87)

**Test suite updates:**

* Updated `test_shuffles_them` to check that judges are always shuffled when the shuffle prefix is empty, removing the previous alphabetical order assertion. (`test/test_judges.rb`)
* Updated `test_shuffles_and_boosts` to verify that boosted judges appear first and the rest are shuffled, not in their original order. (`test/test_judges.rb`)
* Updated `test_demotes_judges` to check that demoted judges appear at the end, regardless of their exact order. (`test/test_judges.rb`)
* Updated `test_boost_and_demote_together` to verify that boosted judges are at the front and demoted judges are at the end, regardless of their exact positions within those groups, and to use the shuffle prefix in the test. (`test/test_judges.rb`)