### PR TITLE
 #323: disable random judge execution where deterministic behavior is required

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -62,7 +62,7 @@ Feature: Update
       n = $fb.insert
       n.type = 'second'
     """
-    Then I run bin/judges with "--verbose update --quiet --lifetime 4 --timeout 3 --max-cycles 5 . simple.fb"
+    Then I run bin/judges with "--verbose update --quiet --lifetime 4 --timeout 3 --max-cycles 5 --shuffle 'first' . simple.fb"
     Then Stdout contains "Update completed in 2 cycle(s), did 3i/0d/3a"
     And Exit code is zero
 
@@ -248,7 +248,7 @@ Feature: Update
     """
       $fb.insert.name = 'beta'
     """
-    Then I run bin/judges with "update --statistics --quiet --max-cycles 2 --lifetime 4 --timeout 3 . stats.fb"
+    Then I run bin/judges with "update --statistics --quiet --max-cycles 2 --lifetime 4 --timeout 3 --shuffle 'alpha' . stats.fb"
     Then Stdout contains "Judge execution summary:"
     Then Stdout contains "alpha"
     Then Stdout contains "beta"


### PR DESCRIPTION
Closes #323 

Add command-line options to specific test scenarios to disable random judge execution where deterministic behavior is required. This will maintain the benefits of shuffling in production while ensuring test stability.