### PR TITLE
Fix long summary line using ellipsized

### DIFF
--- a/lib/judges/commands/test.rb
+++ b/lib/judges/commands/test.rb
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
+require 'ellipsized'
 
 require 'nokogiri'
 require 'factbase'
@@ -106,7 +107,8 @@ class Judges::Test
             format(fmt, 'Script', 'Seconds', 'Result'),
             format(fmt, '---', '---', '---'),
             times.sort_by { |_, v| v }.reverse.map do |script, sec|
-              format(fmt, script, format('%.3f', sec), errors.include?(script) ? 'ERROR' : 'OK')
+short_script = script.ellipsized(40)
+format(fmt, short_script, format('%.3f', sec), errors.include?(script) ? 'ERROR' : 'OK')
             end.join("\n  ")
           ].join("\n  ")
         )


### PR DESCRIPTION
The test summary output included a script name that was too long for the table layout.
Following the suggestion in the issue, I applied the ellipsized gem to shorten long script names:

short_script = script.ellipsized(40)


I verified the behavior locally using a standalone test script.
The summary output now fits the expected width and long lines are truncated correctly.