### PR TITLE
 #344: added support of wildcards in boost and demote options

### DIFF
--- a/bin/judges
+++ b/bin/judges
@@ -120,9 +120,9 @@ class JudgesGLI extend GLI::App
     c.flag([:shuffle], default_value: '')
     c.desc 'Random seed for judge ordering'
     c.flag([:seed], default_value: 0, type: Integer)
-    c.desc 'Prioritize a judge to run before all others'
+    c.desc 'Prioritize a judge to run before all others (supports wildcards with *)'
     c.flag([:boost], multiple: true)
-    c.desc 'Demote a judge to run after all others'
+    c.desc 'Demote a judge to run after all others (supports wildcards with *)'
     c.flag([:demote], multiple: true)
     c.desc 'Maximum time in seconds for the entire update cycle'
     c.flag([:lifetime], default_value: 300, type: Integer)


### PR DESCRIPTION
Closes #344 

This pull request enhances the judge prioritization logic by allowing wildcard pattern matching for judge names in the boost and demote lists. This means you can now use patterns like `test_*` or `zzz*` to boost or demote groups of judges by name, making configuration much more flexible. The changes also add comprehensive tests to ensure this new behavior works correctly.

### Judge prioritization improvements

* Updated the `boost` and `demote` parameters in the `Judges::Judges` class to support wildcard patterns (using `*`) for matching judge names, instead of requiring exact names. [[1]](diffhunk://#diff-6657a041541284f287d3549f7a3f13f8e7502cef90d9dec63f51daf895c5e110L35-R36) [[2]](diffhunk://#diff-6657a041541284f287d3549f7a3f13f8e7502cef90d9dec63f51daf895c5e110L69-R70)
* Refactored prioritization logic to use a new `fits?` method, which matches judge names against wildcard patterns for both boosting and demoting. [[1]](diffhunk://#diff-6657a041541284f287d3549f7a3f13f8e7502cef90d9dec63f51daf895c5e110L99-R101) [[2]](diffhunk://#diff-6657a041541284f287d3549f7a3f13f8e7502cef90d9dec63f51daf895c5e110R127-R141)

### Testing enhancements

* Added new tests to `test/test_judges.rb` to verify that boosting and demoting judges by wildcard patterns works as intended, including combinations of boost and demote patterns.