### PR TITLE
#418: release baza lock on success path of pull

### DIFF
--- a/lib/judges/commands/pull.rb
+++ b/lib/judges/commands/pull.rb
@@ -51,9 +51,8 @@ class Judges::Pull
           end
           fb.import(baza.pull(wait(name, baza, jid, opts['wait'])))
           Judges::Impex.new(@loog, args[1]).export(fb)
-        rescue StandardError => e
+        ensure
           baza.unlock(name, opts['owner'])
-          raise e
         end
         throw :"👍 Pulled #{fb.size} facts by name '#{name}'"
       else

--- a/test/commands/test_pull.rb
+++ b/test/commands/test_pull.rb
@@ -45,6 +45,35 @@ class TestPull < Minitest::Test
     end
   end
 
+  def test_unlocks_baza_on_success
+    WebMock.disable_net_connect!
+    stub_request(:get, 'http://example.org/csrf').to_return(body: 'test-csrf-token')
+    stub_request(:post, %r{http://example.org/lock/foo}).to_return(status: 302)
+    stub_request(:get, 'http://example.org/exists/foo').to_return(body: 'yes')
+    stub_request(:get, 'http://example.org/recent/foo.txt').to_return(body: '42')
+    stub_request(:get, 'http://example.org/finished/42').to_return(body: 'yes')
+    stub_request(:get, 'http://example.org/exit/42.txt').to_return(body: '0')
+    unlock = stub_request(:post, %r{http://example.org/unlock/foo}).to_return(status: 302)
+    fb = Factbase.new
+    fb.insert.foo = 42
+    stub_request(:get, 'http://example.org/pull/42.fb').to_return(body: fb.export, headers: {})
+    Dir.mktmpdir do |d|
+      file = File.join(d, 'base.fb')
+      Judges::Pull.new(Loog::NULL).run(
+        {
+          'token' => '000',
+          'host' => 'example.org',
+          'port' => 80,
+          'ssl' => false,
+          'wait' => 10,
+          'owner' => 'none'
+        },
+        ['foo', file]
+      )
+    end
+    assert_requested(unlock)
+  end
+
   def test_fail_pull_when_job_is_broken
     WebMock.disable_net_connect!
     stub_request(:get, 'http://example.org/csrf').to_return(body: 'test-csrf-token')


### PR DESCRIPTION
@yegor256 this PR fixes #418.

## What was wrong
`Judges::Pull#run` acquired a server lock via `baza.lock` and then released it only inside a `rescue StandardError => e` clause. On the success path the method exits via `throw` placed _outside_ the `begin/rescue` block:

```ruby
baza.lock(name, opts['owner'])
begin
  ...
rescue StandardError => e
  baza.unlock(name, opts['owner'])
  raise e
end
throw :"👍 Pulled #{fb.size} facts by name '#{name}'"  # unlock never reached
```

The `throw` raises `UncaughtThrowError` (no matching `catch`), which is swallowed by the surrounding `elapsed { ... }` block. So the rescue clause never runs on success and the server-side lock stays acquired forever after every successful `judges pull` call.

## What changed
- `lib/judges/commands/pull.rb`: replaced `rescue StandardError; unlock; raise` with `ensure; unlock`, so the unlock runs on both the success and error paths. The `lock` call stays outside the `begin` block so a failed lock does not trigger a spurious unlock.
- `test/commands/test_pull.rb`: added `test_unlocks_baza_on_success`, which asserts that the unlock endpoint is called after a successful pull. The test fails on master and passes with this fix.

## Verification
- All 12 CI checks are green (`rake` on Ubuntu/macOS/Windows, plus `pdd`, `xcop`, `reuse`, `typos`, `eslint`, `markdown-lint`, `actionlint`, `yamllint`, `copyrights`).
- Locally: `bundle exec rake test` &mdash; 136 tests, 0 failures, 0 errors.
- Locally: `bundle exec rubocop lib/judges/commands/pull.rb test/commands/test_pull.rb` &mdash; no offences.

Ready for merge.
