### PR TITLE
#420: forward epoch to Judge in Judges#each

### DIFF
--- a/lib/judges/judges.rb
+++ b/lib/judges/judges.rb
@@ -78,7 +78,7 @@ class Judges::Judges
         next unless File.directory?(d)
         b = File.basename(d)
         next unless File.exist?(File.join(d, "#{b}.rb"))
-        Judges::Judge.new(File.absolute_path(d), @lib, @loog)
+        Judges::Judge.new(File.absolute_path(d), @lib, @loog, epoch: @epoch)
       end
     list.compact!
     list.sort_by!(&:name)

--- a/test/test_judges.rb
+++ b/test/test_judges.rb
@@ -208,6 +208,17 @@ class TestJudges < Minitest::Test
     end
   end
 
+  def test_each_forwards_epoch_to_judge
+    Dir.mktmpdir do |d|
+      save_it(File.join(d, 'foo/foo.rb'), 'puts 1')
+      epoch = Time.utc(2020, 1, 2, 3, 4, 5)
+      judges = Judges::Judges.new(d, nil, Loog::NULL, epoch:)
+      yielded = judges.each.to_a
+      assert_equal(1, yielded.size)
+      assert_equal(epoch, yielded.first.instance_variable_get(:@epoch))
+    end
+  end
+
   def test_boost_and_demote_with_wildcards_together
     Dir.mktmpdir do |d|
       names = %w[priority_one priority_two normal_alpha normal_beta slow_gamma slow_delta].sort


### PR DESCRIPTION
@yegor256 this fixes #420.

## Problem

`Judges::Judges#each` constructed `Judges::Judge` objects without forwarding the `epoch:` keyword argument:

```ruby
# lib/judges/judges.rb (before)
Judges::Judge.new(File.absolute_path(d), @lib, @loog)
```

As a result, every judge yielded by `#each` defaulted to `epoch: Time.now`, ignoring whatever value was passed to `Judges::Judges.new(..., epoch: ...)`. `#get` already forwards `epoch:` correctly; `#each` did not. The bug predates the rename from `start` to `epoch` in #296 — the rename updated `get` but left `each` unchanged.

## Fix

One-line change in `lib/judges/judges.rb`: pass `epoch: @epoch` to `Judges::Judge.new` in `#each`, mirroring `#get`.

## Test

Added `test_each_forwards_epoch_to_judge` in `test/test_judges.rb`. It constructs `Judges::Judges` with a fixed `epoch` (`Time.utc(2020, 1, 2, 3, 4, 5)`), iterates, and asserts the yielded judge's `@epoch` matches. Without the fix, the test fails (`@epoch` is `Time.now`); with the fix, it passes.

## CI

All checks green except the repo-wide pre-existing `License Compliance` (FOSSA) failure, which fails identically on `master` and every recent merged PR (#414, #415, #416, #417, #419) with the same `"2 issues found"` message — unrelated to this change.