### PR TITLE
Add Architecture section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,60 @@ of Ruby scripts that are executed after the judge
 The `expected_failure` (default: `[]`) is a list of strings that must
 be present in the message of the exception being raised.
 
+## Architecture
+
+The core data structure is a
+  [Factbase](https://github.com/yegor256/factbase) — a flat, schemaless,
+  binary-serialized collection of facts (records with named attributes)
+  held in memory during a run. Facts are queried via
+  [XPath](https://www.w3.org/TR/xpath/) expressions rather than SQL.
+  There is no schema to migrate, no ORM layer, and no database process
+  to manage. The factbase binary file is read at the start of each
+  `update` run and written back on exit, making state portable and
+  inspectable via `judges print`. This differs from tools such as
+  [Sidekiq](https://sidekiq.org/) or
+  [ActiveJob](https://guides.rubyonrails.org/active_job_basics.html),
+  which depend on an external database or message broker.
+
+Each judge is a single `.rb` Ruby file in its own directory. It is
+  not a class, a module, or a Rake task — it is a plain script loaded
+  with Ruby's `load(file, true)`, which wraps it in an anonymous module
+  and prevents constants in one judge from leaking into another. All
+  context is injected as Ruby global variables: `$fb` (the factbase),
+  `$loog` (logging), `$options` (configuration), `$global` (shared
+  across all judges in a run), and `$local` (reset after each judge).
+  A new judge author needs to know only those variables; there is no
+  base class to inherit and no interface contract to satisfy.
+
+The `update` command runs all judges in repeated cycles until the
+  factbase stops changing (zero churn) or until the `--max-cycles` or
+  `--lifetime` limit is reached. This fixed-point convergence model is
+  analogous to [Datalog](https://en.wikipedia.org/wiki/Datalog): a
+  judge that inserts a fact in one cycle may trigger a different judge
+  in the next cycle, without any explicit dependency declaration.
+  Pipeline tools such as
+  [Apache Airflow](https://airflow.apache.org/) or
+  [GitHub Actions](https://docs.github.com/en/actions) require a
+  directed acyclic graph defined upfront; judges require none.
+
+Every judge directory contains `.yml` test files alongside its `.rb`
+  script. A YAML file declares the initial facts (`input`), the count
+  of judge executions (`runs`), prerequisite judges (`before`),
+  post-condition scripts (`after`), and
+  [XPath](https://www.w3.org/TR/xpath/) assertions the factbase must
+  satisfy when the judge finishes (`expected`). Running `judges test`
+  creates a fresh, in-memory factbase per test case. Co-locating tests
+  with the script keeps each judge directory self-contained: one
+  directory holds both the deliverable and its verification.
+
+The `push` and `pull` commands exchange the binary factbase with a
+  remote [Baza](https://github.com/yegor256/baza.rb) server via a
+  named-lock protocol. `pull` acquires the lock and downloads the
+  file; `push` uploads the modified file and releases the lock. This
+  lets distributed CI pipelines share a single evolving factbase
+  across multiple jobs without running a database: each job pulls,
+  runs `update` locally, and pushes back.
+
 ## How to contribute
 
 Read


### PR DESCRIPTION
@yegor256, this PR adds an "Architecture" section to README.md.

The section is placed immediately before "How to contribute" and explains five key architectural decisions in the repository, each tied to a concrete design constraint:

1. **Factbase as the data store** — schemaless, XPath-queried, binary-serialized facts in memory, with no external database dependency. Contrasted with Sidekiq/ActiveJob.
2. **Judges as plain scripts** — a judge is a `.rb` file loaded via `load(file, true)` in an anonymous module, with context injected via Ruby globals. No base class, no interface contract.
3. **Multi-cycle convergence loop** — `update` repeats cycles until zero churn, analogous to Datalog fixed-point computation. Contrasted with DAG-based pipelines (Airflow, GitHub Actions).
4. **Co-located YAML tests** — test files sit next to the judge script in the same directory, each specifying inputs, expected XPath assertions, and optional pre/post scripts.
5. **Baza named-lock protocol** — `pull`/`push` acquire and release a server-side named lock to share one evolving factbase across distributed CI jobs.

All lines follow the 80-character wrap convention with two-space continuation indentation. `markdownlint-cli2` reports zero errors.

Ready for merge. @yegor256