### PR TITLE
#289: stop lifetime as normal completion

### DIFF
--- a/lib/judges/commands/update.rb
+++ b/lib/judges/commands/update.rb
@@ -75,9 +75,8 @@ class Judges::Update
       Timeout.timeout(opts['lifetime']) do
         loop_them(judges, fb, churn, opts, options)
       end
-    rescue Timeout::Error, Timeout::ExitException => e
+    rescue Timeout::Error, Timeout::ExitException
       @loog.error("Terminated due to --lifetime=#{opts['lifetime']}")
-      raise e unless opts['quiet']
       @loog.info("Had to stop due to the --lifetime=#{opts['lifetime']}")
     ensure
       impex.export(fb)
@@ -259,8 +258,12 @@ class Judges::Update
         judge.run(fb, global, local, options)
       end
     rescue Timeout::Error, Timeout::ExitException => e
-      @loog.error("Terminated due to --timeout=#{opts['timeout']}")
-      errors << "Judge #{judge.name} stopped by timeout after #{start.ago}: #{e.message}"
+      if opts['lifetime'] && Time.now - @start >= opts['lifetime']
+        @loog.error("Terminated due to --lifetime=#{opts['lifetime']}")
+      else
+        @loog.error("Terminated due to --timeout=#{opts['timeout']}")
+        errors << "Judge #{judge.name} stopped by timeout after #{start.ago}: #{e.message}"
+      end
     end
     fb.churn
   end

--- a/test/commands/test_update.rb
+++ b/test/commands/test_update.rb
@@ -195,10 +195,9 @@ class TestUpdate < Minitest::Test
       save_it(File.join(d, 'foo/foo.rb'), 'sleep 999')
       file = File.join(d, 'base.fb')
       log = Loog::Buffer.new
-      assert_raises(StandardError) do
-        Judges::Update.new(Loog::Tee.new(log, Loog::NULL)).run({ 'lifetime' => 0.1 }, [d, file])
-      end
-      assert_includes(log.to_s, 'execution expired')
+      Judges::Update.new(Loog::Tee.new(log, Loog::NULL)).run({ 'lifetime' => 0.1 }, [d, file])
+      assert_includes(log.to_s, 'Terminated due to --lifetime=0.1')
+      assert_path_exists(file)
     end
   end
 
@@ -370,14 +369,12 @@ class TestUpdate < Minitest::Test
     end
   end
 
-  def test_exports_churn_to_file_despite_error
+  def test_exports_churn_to_file_on_lifetime
     Dir.mktmpdir do |d|
       save_it(File.join(d, 'foo/foo.rb'), '$fb.insert.foo = 1; sleep 999')
       file = File.join(d, 'base.fb')
       churn = File.join(d, 'churn.txt')
-      assert_raises(StandardError) do
-        Judges::Update.new(Loog::NULL).run({ 'lifetime' => 0.1, 'churn' => churn }, [d, file])
-      end
+      Judges::Update.new(Loog::NULL).run({ 'lifetime' => 0.1, 'churn' => churn }, [d, file])
       assert_path_exists(churn)
       content = File.read(churn)
       assert_includes(content, '1i/0d/1a')


### PR DESCRIPTION
Fixes #289.

Stops `--lifetime` expiration from being reported as a per-judge `--timeout` error when the lifetime timeout fires while a judge is running. The update now logs lifetime termination, still exports the factbase and churn file, and preserves the existing per-judge `--timeout` error path.

Validation:
- `env PICKS=yes mise x ruby@3.3 -- bundle exec ruby -Itest -Ilib test/commands/test_update.rb --name '/lifetime|timeout|churn/'` -> 6 tests, 17 assertions, 0 failures
- `env PICKS=yes mise x ruby@3.3 -- bundle exec ruby -Itest -Ilib test/commands/test_update.rb` -> 28 tests, 64 assertions, 0 failures
- `mise x ruby@3.3 -- bundle exec rubocop lib/judges/commands/update.rb test/commands/test_update.rb` -> 2 files inspected, no offenses
- `git diff --check`
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Limitations:
- `mise x ruby@3.3 -- bundle exec rake test` ran 137 tests and 423 assertions with 0 failures, but hit one local `tidy -e .../temp/base.html` error in `test_print_to_html`.
- Full `bundle exec rubocop` reports four existing symbol-conversion warnings in unrelated command files.
