### PR TITLE
#450: map equals-less tokens to 'true' instead of nil

### DIFF
--- a/lib/judges/options.rb
+++ b/lib/judges/options.rb
@@ -138,7 +138,7 @@ class Judges::Options
         .map(&:strip)
         .reject(&:empty?)
         .map { |s| s.split('=', 2) }
-        .map { |a| a.size == 1 ? [a[0], nil] : a }
+        .map { |a| a.size == 1 ? [a[0], 'true'] : a }
         .reject { |a| a[0].empty? }
         .to_h
     end

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -52,6 +52,19 @@ class TestOptions < Minitest::Test
     assert_equal(42, opts.b)
   end
 
+  def test_equals_less_token_in_string
+    opts = Judges::Options.new('token=abc123,max_speed=100,debug')
+    assert_equal('abc123', opts.token)
+    assert_equal(100, opts.max_speed)
+    assert_equal('true', opts.debug)
+  end
+
+  def test_equals_less_token_in_array
+    opts = Judges::Options.new(['token=abc123', 'debug'])
+    assert_equal('abc123', opts.token)
+    assert_equal('true', opts.debug)
+  end
+
   def test_with_hash
     opts = Judges::Options.new('foo' => 42, 'bar' => 'hello')
     assert_equal(42, opts.foo)


### PR DESCRIPTION
Closes #450. The docstring on `Judges::Options#to_h` promises that a token supplied without an equals sign maps to the string value `'true'`, but `parse_pairs` produced `[key, nil]` and the next `.compact` call in `normalize_to_h` dropped the entry before `transform_values` could rewrite the nil. Mapping equals-less tokens to `'true'` inside `parse_pairs` itself restores the documented behavior.

After the change, `Judges::Options.new('token=abc,debug').debug` returns `'true'` and `Judges::Options.new(['debug']).debug` returns `'true'`. The hash-input case stays untouched, so `Judges::Options.new('foo' => nil).foo` still returns nil and the existing `test_with_nil_values` keeps passing.

Local checks on master at 120275a:
- `bin/rake test` ran 139 tests, 429 assertions, 0 failures, 0 errors, 1 skip (the same skip as on master)
- `bin/rubocop lib/judges/options.rb test/test_options.rb` reported 0 offenses
- Full `bin/rubocop` reported 4 pre-existing offenses in other files, none in the files touched here
