### PR TITLE
#448: dup hash before merging in Options#+

### DIFF
--- a/lib/judges/options.rb
+++ b/lib/judges/options.rb
@@ -64,7 +64,7 @@ class Judges::Options
   #   merged = opts1 + opts2
   #   # merged now has token=xyz, debug=true, verbose=true
   def +(other)
-    h = to_h
+    h = to_h.dup
     other.to_h.each do |k, v|
       h[k] = v
     end

--- a/test/test_options.rb
+++ b/test/test_options.rb
@@ -80,4 +80,11 @@ class TestOptions < Minitest::Test
     assert_equal(42, opts.a, opts)
     assert_equal(7, opts.b, opts)
   end
+
+  def test_merge_does_not_mutate_receiver
+    a = Judges::Options.new(['a = 1'])
+    assert_equal(2, (a + Judges::Options.new(['b = 2'])).to_h.size)
+    assert_equal(1, a.to_h.size, 'receiver must not absorb keys from the other operand')
+    refute(a.to_h.key?(:b))
+  end
 end


### PR DESCRIPTION
## What happens

In `lib/judges/options.rb`, `Judges::Options#+` does:

```ruby
def +(other)
  h = to_h
  other.to_h.each do |k, v|
    h[k] = v
  end
  Judges::Options.new(h)
end
```

`to_h` is memoized into `@to_h` and returns that exact hash object, so `h` is
the same object as the receiver's `@to_h`. The `h[k] = v` writes therefore
mutate the receiver's cached hash: after `a + b`, the receiver `a` silently
absorbs every key from `b`, even though only the returned value should carry
the merged state. The new `Judges::Options.new(h)` is also built from that
same hash, so the returned instance shares storage with `a` — mutating either
side leaks through the other.

This breaks the documented contract of `+` ("Creates a new Options instance
containing values from both this instance and the other") and quietly
accumulates state across what should be independent objects.

## What should happen

`a + b` must return a new, independent `Options` instance without modifying
`a` or `b`.

## Fix

One-line change at `lib/judges/options.rb:67`:

```diff
 def +(other)
-    h = to_h
+    h = to_h.dup
   other.to_h.each do |k, v|
     h[k] = v
   end
   Judges::Options.new(h)
 end
```

## Test

Added `test_merge_does_not_mutate_receiver` in `test/test_options.rb`, which
asserts the receiver's key count is unaffected and the receiver does not
gain the other operand's key after `+`.

## Verification

- `bundle exec rubocop lib/judges/options.rb test/test_options.rb` — no offenses
- `bundle exec rake test` — 138 tests, 0 failures (1 pre-existing, unrelated
  error in `TestPrint#test_print_to_html` due to `/bin/bash` not existing on
  this NixOS sandbox — not caused by this change)

Closes #448
