### PR TITLE
#454 Fix disable/enable dominance in Judges::Categories#ok?

### DIFF
--- a/lib/judges/categories.rb
+++ b/lib/judges/categories.rb
@@ -54,10 +54,8 @@ class Judges::Categories
   def ok?(cats)
     cats = [] if cats.nil?
     cats = [cats] unless cats.is_a?(Array)
-    cats.each do |c|
-      return false if @disable.any?(c)
-      return true if @enable.any?(c)
-    end
+    return false if cats.any? { |c| @disable.any?(c) }
+    return true if cats.any? { |c| @enable.any?(c) }
     return true if @enable.empty?
     false
   end

--- a/test/test_categories.rb
+++ b/test/test_categories.rb
@@ -22,6 +22,13 @@ class TestCategories < Minitest::Test
     refute(cats.ok?(nil))
   end
 
+  def test_disable_dominates_no_matter_order
+    cats = Judges::Categories.new(%w[foo bar], ['bad'])
+    refute(cats.ok?(%w[bad other]))
+    refute(cats.ok?(%w[foo bad]))
+    refute(cats.ok?(%w[other bad foo]))
+  end
+
   def test_all_enabled
     cats = Judges::Categories.new([], ['bad'])
     assert(cats.ok?(nil))


### PR DESCRIPTION
Fixes #454

Bug: `Categories#ok?` checks disable/enable in a single pass — first match wins. When an enabled category appears before a disabled one in the input, it returns `true` before reaching the disabled entry.

Fix: Split into two passes — scan all categories against `@disable` first, then against `@enable`. This matches the documented precedence.

```ruby
cats = Judges::Categories.new(%w[foo bar], ['bad'])
cats.ok?(%w[foo bad])  # was true, now false ✓
```

Added `test_disable_dominates_no_matter_order` covering all input orderings.