### PR TITLE
#463 Fix assert_once: read from yaml instead of opts

### DIFF
--- a/lib/judges/commands/test.rb
+++ b/lib/judges/commands/test.rb
@@ -232,7 +232,7 @@ class Judges::Test
         end
       end
       next unless assert
-      assert(judge, tname, fb, yaml) if r == runs || opts['assert_once'].is_a?(FalseClass)
+      assert(judge, tname, fb, yaml) if r == runs || yaml['assert_once'].is_a?(FalseClass)
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/test/commands/test_test.rb
+++ b/test/commands/test_test.rb
@@ -131,6 +131,24 @@ class TestTest < Minitest::Test
     end
   end
 
+  def test_assert_once_honored
+    Dir.mktmpdir do |d|
+      save_it(File.join(d, 'foo/foo.rb'), '$fb.insert.foo = 42')
+      save_it(
+        File.join(d, 'foo/x.yml'),
+        <<-YAML
+        runs: 3
+        assert_once: false
+        input: []
+        expected:
+          - /fb/f[foo = 42]
+        YAML
+      )
+      Judges::Test.new(Loog::NULL).run({}, [d])
+      assert_path_exists(d)
+    end
+  end
+
   def test_with_expected_failure
     Dir.mktmpdir do |d|
       save_it(File.join(d, 'foo/foo.rb'), 'raise "this is intentional";')


### PR DESCRIPTION
Fixes #463

Bug: `test_one` reads `assert_once` from `opts` (CLI options hash) when deciding whether to run assertions after every iteration. But `assert_once` is only ever set in test fixture YAML files (e.g., `features/test.feature:89`), never as a CLI option. So `opts['assert_once']` is always `nil`, and the fixture's `assert_once: false` is ignored — assertions always run only after the last iteration regardless.

Fix: Read `yaml['assert_once']` instead of `opts['assert_once']`, so that `assert_once: false` in a fixture YAML makes assertions run after every iteration as intended.

```diff
- assert(judge, tname, fb, yaml) if r == runs || opts['assert_once'].is_a?(FalseClass)
+ assert(judge, tname, fb, yaml) if r == runs || yaml['assert_once'].is_a?(FalseClass)
```