### PR TITLE
#464 Rename sha384 to sha256 to match actual implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,7 +53,7 @@ Elegant/GoodMethodName:
     - import_to
     - loop_them
     - one_judge
-    - sha384
+    - sha256
     - save_it
     - '+'
     - build_options

--- a/lib/judges/commands/print.rb
+++ b/lib/judges/commands/print.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'base64'
+require 'digest'
 require 'elapsed'
 require 'factbase'
 require 'fileutils'
@@ -91,13 +92,13 @@ class Judges::Print
         'hidden' => opts['hidden'] || '_id,_version,_time,_job',
         'highlighted' => opts['highlighted'] || 'stale,tombstone',
         'version' => Judges::VERSION,
-        'css_hash' => sha384(opts, 'index.css'),
-        'js_hash' => sha384(opts, 'index.js')
+        'css_hash' => sha256(opts, 'index.css'),
+        'js_hash' => sha256(opts, 'index.js')
       )
     )
   end
 
-  def sha384(opts, asset)
+  def sha256(opts, asset)
     return 'sha256-offline' if opts['offline']
     with_retries do
       url = "https://yegor256.github.io/judges/assets/#{asset}"


### PR DESCRIPTION
Fixes #464

The `sha384` method in `Judges::Print` is named after SHA-384 but actually computes SHA-256:
- The offline placeholder returns `sha256-offline`
- The hash uses `Digest::SHA256` with `sha256-` prefix
- Only the method name said `384`

**Changes:**
1. Renamed method `sha384` → `sha256` (and its two call sites)
2. Added explicit `require 'digest'` (was working through transitive deps)
3. Updated `Elegant/GoodMethodName` AllowedNames in `.rubocop.yml`

The XSLT (`assets/index.xsl`) already uses `sha256-` prefixed hashes for these local assets via `$css_hash`/`$js_hash` params — no changes needed there.