### PR TITLE
#476: escape regex metacharacters in boost/demote patterns

### DIFF
--- a/lib/judges/judges.rb
+++ b/lib/judges/judges.rb
@@ -134,7 +134,8 @@ class Judges::Judges
   end
 
   # Checks if a judge name matches any of the given patterns.
-  # Patterns can contain '*' wildcards which are converted to '.*' regex patterns.
+  # Patterns can contain '*' wildcards which are converted to '.*' regex patterns;
+  # every other character matches literally.
   #
   # @param [String] name The judge name to check
   # @param [Array<String>, String, nil] patterns Array of patterns, or single pattern string, may contain '*' wildcards
@@ -142,7 +143,7 @@ class Judges::Judges
   def fits?(name, patterns)
     return false if patterns.nil? || patterns.empty?
     Array(patterns).any? do |pattern|
-      name.match?("\\A#{pattern.gsub('*', '.*')}\\z")
+      name.match?("\\A#{Regexp.escape(pattern).gsub('\\*', '.*')}\\z")
     end
   end
 end

--- a/test/test_judges.rb
+++ b/test/test_judges.rb
@@ -112,6 +112,19 @@ class TestJudges < Minitest::Test
     end
   end
 
+  def test_demote_pattern_treats_dot_literally
+    Dir.mktmpdir do |d|
+      names = %w[my.judge myxjudge myzz]
+      names.each do |n|
+        save_it(File.join(File.join(d, n), "#{n}.rb"), 'puts 1')
+      end
+      assert_equal(
+        %w[myxjudge myzz my.judge],
+        Judges::Judges.new(d, nil, Loog::NULL, shuffle: 'my', demote: ['my.judge']).each.to_a.map(&:name)
+      )
+    end
+  end
+
   def test_same_seed_produces_same_order
     Dir.mktmpdir do |d|
       names = %w[alpha beta gamma delta epsilon zeta eta theta].sort


### PR DESCRIPTION
Closes #476.

`Judges::Judges#fits?` passed `--boost`/`--demote` patterns into the match regex with only `*` translated, so any other regex metacharacter kept its regex meaning: `--demote=my.judge` also demoted `myxjudge`. Per the feature's originating semantics (#344: "`*` means `.*` and that's it"), the pattern is now `Regexp.escape`d first and only the escaped `\*` is expanded back to `.*`.

The new test pins three judges (`my.judge`, `myxjudge`, `myzz`) with shuffling disabled via the `shuffle:` prefix and asserts the exact order after `demote: ['my.judge']` — on master it fails because `myxjudge` gets demoted too.

Tests: 17 tests, 0 failures; rubocop: no offenses.
