### PR TITLE
Set judges epoch to update start instead of nil

### DIFF
--- a/lib/judges/commands/update.rb
+++ b/lib/judges/commands/update.rb
@@ -49,7 +49,7 @@ class Judges::Update
     options = build_options(opts)
     judges = Judges::Judges.new(
       dir, opts['lib'], @loog,
-      epoch: @epoch, shuffle: opts['shuffle'], boost: opts['boost'],
+      epoch: @start, shuffle: opts['shuffle'], boost: opts['boost'],
       demote: opts['demote'], seed: opts['seed']
     )
     churn = Factbase::Churn.new

--- a/test/commands/test_update.rb
+++ b/test/commands/test_update.rb
@@ -29,6 +29,15 @@ class TestUpdate < Minitest::Test
     end
   end
 
+  def test_sets_epoch_to_update_start
+    Dir.mktmpdir do |d|
+      save_it(File.join(d, 'foo/foo.rb'), "$loog.info(\"captured-epoch=\#{$epoch.class}\")")
+      log = Loog::Buffer.new
+      Judges::Update.new(log).run({}, [d, File.join(d, 'base.fb')])
+      assert_includes(log.to_s, 'captured-epoch=Time')
+    end
+  end
+
   def test_with_only_one_judge
     Dir.mktmpdir do |d|
       save_it(File.join(d, 'foo/foo.rb'), 'return if $fb.size > 2; $fb.insert')


### PR DESCRIPTION
`Judges::Update` handed `epoch: @epoch` to `Judges::Judges`, but `@epoch` is never assigned in that class — only `@start` is — so `$epoch` reached every judge as nil. This switches it to `@start`, the real update-start time, and adds a test at the `update` command level that catches the nil.

With `$epoch` nil, the `fbe` gem's lifetime-aware graceful stop (`Fbe.over?`) measured its budget from each judge's own start rather than the update's start, so a judge that began late in the `--lifetime` window never hit the stop threshold and got hard-killed by the `Timeout` wrapper mid-transaction. #420 had already fixed the downstream `Judges::Judges#each` forwarding, but this nil source sat above it.

Closes #483.